### PR TITLE
Simplify install steps and optimize release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,8 @@ lscolors = "0.9.0"
 terminal_size = "0.1.17"
 which = "4.2.4"
 rayon = "1.5.1"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ The `httm` project contains only a few components:
 
     ```bash
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh 
-    git clone https://github.com/kimono-koans/httm.git
-    cargo install --path ./httm/
+    cargo install --git https://github.com/kimono-koans/httm.git
     ```
 2. The optional `zsh` hot-key bindings: Use `ESC+s` to select snapshots filenames to be dropped to your command line (for instance after the `cat` command), or use `ESC+m` to browse for all of a file's snapshots. After you install the `httm` binary, to copy the hot key script to your home directory, and source that script within your `.zshrc`:
 


### PR DESCRIPTION
A few simple changes:

* Combine the git clone and build steps into a single command
* Enable linker optimizations (https://doc.rust-lang.org/cargo/reference/profiles.html#lto)
* Automatically strip the release binary (reduces the size of the release binary)