### PR TITLE
Fix multiple btrfs roots

### DIFF
--- a/src/parse/mounts.rs
+++ b/src/parse/mounts.rs
@@ -113,7 +113,7 @@ impl MaxLen for MapOfDatasets {
 
 pub static PROC_MOUNTS: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("/proc/mounts"));
 
-static ETC_MNTTAB: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("/proc/mounts"));
+static ETC_MNTTAB: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("/etc/mnttab"));
 
 pub struct BaseFilesystemInfo {
     pub map_of_datasets: MapOfDatasets,

--- a/src/parse/snaps.rs
+++ b/src/parse/snaps.rs
@@ -216,8 +216,6 @@ impl MapOfSnaps {
                     return Some(snap_mount);
                 }
 
-                eprintln!("{:?}", snap_mount);
-
                 snap_mount = base_mount.join(relative);
 
                 if snap_mount.exists() {


### PR DESCRIPTION
```
/dev/zd0 on /mnt type btrfs (rw,relatime,ssd,space_cache=v2,subvolid=5,subvol=/)
/dev/zd0 on /mnt/garden type btrfs (rw,relatime,ssd,space_cache=v2,subvolid=256,subvol=/garden)
/dev/zd16 on /media type btrfs (rw,relatime,ssd,space_cache=v2,subvolid=5,subvol=/)
/dev/zd16 on /media/@pot type btrfs (rw,relatime,ssd,space_cache=v2,subvolid=256,subvol=/@pot)
```

It's possible to have multiple btrfs roots.  Here we verify that any root is the sub's underlying root.