### PR TITLE
True btrfs snapshot name support

### DIFF
--- a/src/lookup/snap_names.rs
+++ b/src/lookup/snap_names.rs
@@ -19,14 +19,12 @@ use crate::config::generate::ListSnapsFilters;
 use crate::data::paths::PathDeconstruction;
 use crate::data::paths::{PathData, ZfsSnapPathGuard};
 use crate::library::results::{HttmError, HttmResult};
-use crate::library::utility::find_common_path;
 use crate::lookup::versions::VersionsMap;
 use crate::parse::mounts::FilesystemType;
 use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::path::PathBuf;
-use std::sync::Once;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SnapNameMap {
@@ -66,67 +64,49 @@ impl SnapNameMap {
 
                 true
             })
-            .map(|(pathdata, snaps)| {
-                // use par iter here because no one else is using the global rayon threadpool any more
-                let snap_names: Vec<String> = snaps
-                    .par_iter()
-                    .filter_map(|snap_pd| {
-                        let opt_proximate_dataset = pathdata.proximate_dataset().ok();
+            .filter_map(|(pathdata, snaps)| {
+               let opt_proximate_dataset = pathdata.proximate_dataset().ok();
 
-                        match pathdata.fs_type(opt_proximate_dataset) {
-                            Some(FilesystemType::Zfs) => {
+               match pathdata.fs_type(opt_proximate_dataset) {
+                    Some(FilesystemType::Zfs) => {
+                        // use par iter here because no one else is using the global rayon threadpool any more
+                        let snap_names: Vec<PathBuf> = snaps
+                            .par_iter()
+                            .filter_map(|snap_pd| {
                                 ZfsSnapPathGuard::new(snap_pd).and_then(|spd| spd.source(opt_proximate_dataset))
-                            }
-                            Some(FilesystemType::Btrfs(_)) => {
-                                static NOTICE_NON_ZFS: std::sync::Once = Once::new();
-                                
-                                NOTICE_NON_ZFS.call_once( || {
-                                    eprintln!("WARN: Snapshot name determination for non-ZFS datasets are merely best guess efforts.  Use with caution.");
-                                });
+                            })
+                            .collect();
 
-                                if snaps.len() <= 1 {
-                                    eprintln!("WARN: Could not determine snapshot name for snapshot location: {:?}", snap_pd.path());
-                                    return None;
-                                }
-
-                                let opt_common_path = find_common_path(snaps.into_iter().map(|p| p.path()));
-
-                                let Some(common_path) = opt_common_path else {
-                                    eprintln!("WARN: Could not determine common path for snapshot location: {:?}", snap_pd.path());
-                                    return None;
-                                };
-
-                                let path_string =  snap_pd.path().to_string_lossy();
-                                let relative_path =  pathdata.relative_path(opt_proximate_dataset?).ok()?;
-
-                                let sans_prefix = path_string.strip_prefix(common_path.to_string_lossy().as_ref())?;
-                                let sans_suffix = sans_prefix.strip_suffix(relative_path.to_string_lossy().as_ref())?;
-                                let trim_slashes = sans_suffix.trim_matches('/');
-
-                                if trim_slashes.is_empty() {
-                                    return None;
-                                }
-
-                                Some(PathBuf::from(trim_slashes))
-                            },
-                            _ => {
-                                eprintln!("ERROR: LIST_SNAPS is a ZFS and btrfs only option.  Path does not appear to be on a supported dataset: {:?}", snap_pd.path());
-                                None
-                            }   
-                        }
-                    })
-                    .filter(|snap| {
-                        if let Some(filters) = opt_filters {
-                            if let Some(names) = &filters.name_filters {
-                                return names.iter().any(|pattern| snap.to_string_lossy().contains(pattern));
+                        Some((pathdata, snap_names))
+                    }
+                    Some(FilesystemType::Btrfs(opt_additional_btrfs_data)) => {
+                        if let Some(additional_btrfs_data) = opt_additional_btrfs_data {
+                            if let Some(proximate_dataset) =  opt_proximate_dataset {
+                                if let Some(new_map) = additional_btrfs_data.snap_names.get() {
+                                    return new_map.get(proximate_dataset).map(|vec| (pathdata, vec.into_iter().cloned().collect()));
+                                }                             
                             }
                         }
-                        true
-                    })
-                    .map(|path| path.to_string_lossy().to_string())
-                    .collect();
-
-                (pathdata, snap_names)
+                        
+                        None
+                    },
+                    _ => {
+                        eprintln!("ERROR: LIST_SNAPS is a ZFS and btrfs only option.  Path does not appear to be on a supported dataset: {:?}", pathdata.path());
+                        None
+                    }   
+                }
+            })
+            .map(|(mount, snaps)| {
+                let vec_snaps: Vec<_> = snaps.iter().map(|p| p.to_string_lossy().to_string()).collect();
+                (mount, vec_snaps)
+            })
+            .filter(|(_pathdata, snaps)| {
+                if let Some(filters) = opt_filters {
+                    if let Some(names) = &filters.name_filters {
+                        return names.iter().any(|pattern| snaps.iter().any(|snap| snap.contains(pattern)));
+                    }
+                }
+                true
             })
             .filter_map(|(pathdata, mut vec_snaps)| {
                 if let Some(mode_filter) = opt_filters {

--- a/src/parse/aliases.rs
+++ b/src/parse/aliases.rs
@@ -22,7 +22,7 @@ use hashbrown::HashMap;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemotePathAndFsType {
     pub remote_dir: PathBuf,
     pub fs_type: FilesystemType,


### PR DESCRIPTION
Cleanup

Closer

Closer

Closer

Retry

Revert "impl snap names from initial btrfs snap search"

This reverts commit 79791eb49259d81a92e4e0330372897b32db1ccb.

impl snap names from initial btrfs snap search

Swap None with Some of additional data

Cleanup

Impl full btrfs support for list snaps by using btrfs cmd

Initial commit