### PR TITLE
Lazy eval of snap locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,18 +150,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -489,7 +489,7 @@ dependencies = [
 name = "httm"
 version = "0.44.1"
 dependencies = [
- "clap 4.5.23",
+ "clap 4.5.26",
  "crossbeam-channel",
  "exacl",
  "foldhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ xattr = { version = "1.4.0", default-features = false, optional = true }
 
 [dependencies]
 foldhash = { version = "0.1.4", default-features = true }
-clap = { version = "4.5.23", default-features = true, features = [
+clap = { version = "4.5.26", default-features = true, features = [
     "std",
     "cargo",
 ] }

--- a/src/config/generate.rs
+++ b/src/config/generate.rs
@@ -582,10 +582,20 @@ fn parse_args() -> ArgMatches {
                 .action(ArgAction::SetTrue)
         )
         .arg(
+            Arg::new("LAZY")
+                .long("lazy")
+                .help("by default, all snapshot locations are discovered at initial program execution, however, here, \
+                a user may request that the program lazily wait until a search is executed before resolving any path's snapshot locations.  \
+                This provides the most accurate metadata possible, but, given the additional IO, may feel slower on older systems, with only marginal benefit.  \
+                For now, this option is only available on filesystems with well defined snapshot locations (not BTRFS datasets).")
+                .display_order(35)
+                .action(ArgAction::SetTrue)
+        )
+        .arg(
             Arg::new("DEBUG")
                 .long("debug")
                 .help("print configuration and debugging info")
-                .display_order(35)
+                .display_order(36)
                 .action(ArgAction::SetTrue)
         )
         .arg(
@@ -593,7 +603,7 @@ fn parse_args() -> ArgMatches {
                 .long("install-zsh-hot-keys")
                 .help("install zsh hot keys to the users home directory, and then exit")
                 .exclusive(true)
-                .display_order(36)
+                .display_order(37)
                 .action(ArgAction::SetTrue)
         )
         .get_matches()
@@ -612,6 +622,7 @@ pub struct Config {
     pub opt_json: bool,
     pub opt_one_filesystem: bool,
     pub opt_no_clones: bool,
+    pub opt_lazy: bool,
     pub dedup_by: DedupBy,
     pub opt_bulk_exclusion: Option<BulkExclusion>,
     pub opt_last_snap: Option<LastSnapMode>,
@@ -650,6 +661,7 @@ impl Config {
         };
 
         let opt_debug = matches.get_flag("DEBUG");
+        let opt_lazy = matches.get_flag("LAZY");
 
         // current working directory will be helpful in a number of places
         let pwd = pwd()?;
@@ -686,6 +698,7 @@ impl Config {
         let dataset_collection = FilesystemInfo::new(
             opt_alt_replicated,
             opt_debug,
+            opt_lazy,
             opt_remote_dir,
             opt_local_dir,
             opt_map_aliases,
@@ -984,6 +997,7 @@ impl Config {
             opt_json,
             opt_one_filesystem,
             opt_no_clones,
+            opt_lazy,
             dedup_by,
             requested_utc_offset,
             exec_mode,

--- a/src/data/selection.rs
+++ b/src/data/selection.rs
@@ -143,6 +143,7 @@ impl From<Vec<PathData>> for Config {
             opt_json: false,
             opt_one_filesystem: false,
             opt_no_clones: false,
+            opt_lazy: config.opt_lazy,
             opt_bulk_exclusion: None,
             opt_last_snap: None,
             opt_preview: None,

--- a/src/lookup/deleted.rs
+++ b/src/lookup/deleted.rs
@@ -83,7 +83,7 @@ impl DeletedFiles {
         // compare local filenames to all unique snap filenames - none values are unique, here
         search_bundle
             .snap_mounts
-            .iter()
+            .into_iter()
             .map(|path| path.join(search_bundle.relative_path.as_os_str()))
             .flat_map(std::fs::read_dir)
             .flatten()

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,8 @@ mod zfs {
 use crate::config::generate::InteractiveMode;
 use crate::interactive::browse::InteractiveBrowse;
 use crate::interactive::select::InteractiveSelect;
+use crate::library::utility::date_string;
+use crate::library::utility::DateFormat;
 use background::recursive::NonInteractiveRecursiveWrapper;
 use config::generate::{Config, ExecMode};
 use display::maps::PrintAsMap;
@@ -88,6 +90,7 @@ use lookup::snap_names::SnapNameMap;
 use lookup::versions::VersionsMap;
 use roll_forward::exec::RollForward;
 use std::sync::LazyLock;
+use std::time::SystemTime;
 use zfs::snap_mounts::SnapshotMounts;
 
 pub const ZFS_HIDDEN_DIRECTORY: &str = ".zfs";
@@ -149,6 +152,21 @@ fn exec() -> HttmResult<()> {
 
                     let output_buf = DisplayWrapper::from(&GLOBAL_CONFIG, versions_map).to_string();
 
+                    if GLOBAL_CONFIG.opt_lazy {
+                        let date_string = date_string(
+                            GLOBAL_CONFIG.requested_utc_offset,
+                            &SystemTime::now(),
+                            DateFormat::Timestamp,
+                        );
+
+                        let notice = format!(
+                            "NOTICE: Snapshot data accurate as of system time: {}\n",
+                            date_string
+                        );
+
+                        eprintln!("{}", &notice);
+                    }
+
                     print_output_buf(&output_buf)
                 }
             }
@@ -157,6 +175,21 @@ fn exec() -> HttmResult<()> {
         ExecMode::BasicDisplay | ExecMode::NumVersions(_) => {
             let versions_map = VersionsMap::new(&GLOBAL_CONFIG, &GLOBAL_CONFIG.paths)?;
             let output_buf = DisplayWrapper::from(&GLOBAL_CONFIG, versions_map).to_string();
+
+            if GLOBAL_CONFIG.opt_lazy {
+                let date_string = date_string(
+                    GLOBAL_CONFIG.requested_utc_offset,
+                    &SystemTime::now(),
+                    DateFormat::Timestamp,
+                );
+
+                let notice = format!(
+                    "NOTICE: Snapshot data accurate as of system time: {}\n",
+                    date_string
+                );
+
+                eprintln!("{}", &notice);
+            }
 
             print_output_buf(&output_buf)
         }
@@ -170,6 +203,21 @@ fn exec() -> HttmResult<()> {
             let printable_map = PrintAsMap::from(&snap_name_map);
             let output_buf = printable_map.to_string();
 
+            if GLOBAL_CONFIG.opt_lazy {
+                let date_string = date_string(
+                    GLOBAL_CONFIG.requested_utc_offset,
+                    &SystemTime::now(),
+                    DateFormat::Timestamp,
+                );
+
+                let notice = format!(
+                    "NOTICE: Snapshot data accurate as of system time: {}\n",
+                    date_string
+                );
+
+                eprintln!("{}", &notice);
+            }
+
             print_output_buf(&output_buf)
         }
         ExecMode::Prune(opt_filters) => {
@@ -180,6 +228,21 @@ fn exec() -> HttmResult<()> {
             let mounts_map = &MountsForFiles::new(mount_display)?;
             let printable_map: PrintAsMap = mounts_map.into();
             let output_buf = printable_map.to_string();
+
+            if GLOBAL_CONFIG.opt_lazy {
+                let date_string = date_string(
+                    GLOBAL_CONFIG.requested_utc_offset,
+                    &SystemTime::now(),
+                    DateFormat::Timestamp,
+                );
+
+                let notice = format!(
+                    "NOTICE: Snapshot data accurate as of system time: {}\n",
+                    date_string
+                );
+
+                eprintln!("{}", &notice);
+            }
 
             print_output_buf(&output_buf)
         }


### PR DESCRIPTION
Move MapOfSnaps out of initial gen

Fn-ize per mount snap discover

MapOfSnaps optional, lock MaxLen value

Only loop when there are some network mounts

Semi-functional

Tweaks to struct

Add config option and printed notice

Update notice when browsing

Better help, better notices

Cleanup

Cleanup

Cleanup

Cleanup

Inline hot path